### PR TITLE
Bugfix: Support Empty array of stacks

### DIFF
--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: nick-fields/assert-action@v1
         with:
           actual: ${{ needs.test.outputs.matrix }}
-          expected: '{"include":[]}'
+          expected: ''
 
   teardown:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
 outputs:
   matrix:
     description: A matrix suitable for extending matrix size workaround (see README)
-    value: ${{ steps.matrix.outputs.output }}
+    value: ${{ steps.matrix.outputs.output != '{"include":[]}' && steps.matrix.outputs.output || '' }}
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## what
* the output `{includes: [] }` is not a valid workflow syntax and shouldn't be used as the default output if an empty array is passed in.
