### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -43,7 +43,7 @@ jobs:
     needs: [test]
     steps:
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: ${{ needs.test.outputs.matrix }}
           expected: '{"include":[]}'

--- a/.github/workflows/test-nestried-matrices-1-input-matrix.yml
+++ b/.github/workflows/test-nestried-matrices-1-input-matrix.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: ${{ needs.test.outputs.matrix }}
           expected: '{"include":[{"version":"10","os":"ubuntu-latest","arch":"amd64"},{"version":"10","os":"ubuntu-latest","arch":"arm64"},{"version":"10","os":"windows-latest","arch":"amd64"},{"version":"10","os":"windows-latest","arch":"arm64"},{"version":"12","os":"ubuntu-latest","arch":"amd64"},{"version":"12","os":"ubuntu-latest","arch":"arm64"},{"version":"12","os":"windows-latest","arch":"amd64"},{"version":"12","os":"windows-latest","arch":"arm64"},{"version":"14","os":"ubuntu-latest","arch":"amd64"},{"version":"14","os":"ubuntu-latest","arch":"arm64"},{"version":"14","os":"windows-latest","arch":"amd64"},{"version":"14","os":"windows-latest","arch":"arm64"}]}'

--- a/.github/workflows/test-nestried-matrices-1.yml
+++ b/.github/workflows/test-nestried-matrices-1.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: ${{ needs.test.outputs.matrix }}
           expected: '{"include":[{"version":"10","os":"ubuntu-latest","arch":"amd64"},{"version":"10","os":"ubuntu-latest","arch":"arm64"},{"version":"10","os":"windows-latest","arch":"amd64"},{"version":"10","os":"windows-latest","arch":"arm64"},{"version":"12","os":"ubuntu-latest","arch":"amd64"},{"version":"12","os":"ubuntu-latest","arch":"arm64"},{"version":"12","os":"windows-latest","arch":"amd64"},{"version":"12","os":"windows-latest","arch":"arm64"},{"version":"14","os":"ubuntu-latest","arch":"amd64"},{"version":"14","os":"ubuntu-latest","arch":"arm64"},{"version":"14","os":"windows-latest","arch":"amd64"},{"version":"14","os":"windows-latest","arch":"arm64"}]}'

--- a/.github/workflows/test-nestried-matrices-2.yml
+++ b/.github/workflows/test-nestried-matrices-2.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: ${{ needs.test.outputs.matrix }}
           expected: '{"include":[{"name":"amd64","items":"{\"include\":[{\"version\":\"10\",\"os\":\"ubuntu-latest\",\"arch\":\"amd64\"},{\"version\":\"10\",\"os\":\"windows-latest\",\"arch\":\"amd64\"},{\"version\":\"12\",\"os\":\"ubuntu-latest\",\"arch\":\"amd64\"},{\"version\":\"12\",\"os\":\"windows-latest\",\"arch\":\"amd64\"},{\"version\":\"14\",\"os\":\"ubuntu-latest\",\"arch\":\"amd64\"},{\"version\":\"14\",\"os\":\"windows-latest\",\"arch\":\"amd64\"}]}"},{"name":"arm64","items":"{\"include\":[{\"version\":\"10\",\"os\":\"ubuntu-latest\",\"arch\":\"arm64\"},{\"version\":\"10\",\"os\":\"windows-latest\",\"arch\":\"arm64\"},{\"version\":\"12\",\"os\":\"ubuntu-latest\",\"arch\":\"arm64\"},{\"version\":\"12\",\"os\":\"windows-latest\",\"arch\":\"arm64\"},{\"version\":\"14\",\"os\":\"ubuntu-latest\",\"arch\":\"arm64\"},{\"version\":\"14\",\"os\":\"windows-latest\",\"arch\":\"arm64\"}]}"}]}'

--- a/.github/workflows/test-nestried-matrices-3.yml
+++ b/.github/workflows/test-nestried-matrices-3.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: ${{ needs.test.outputs.matrix }}
           expected: '{"include":[{"name":"amd64","items":"{\"include\":[{\"name\":\"10-ubuntu-latest-amd64 - 14-windows-latest-amd64\",\"items\":\"{\\\"include\\\":[{\\\"version\\\":\\\"10\\\",\\\"os\\\":\\\"ubuntu-latest\\\",\\\"arch\\\":\\\"amd64\\\"},{\\\"version\\\":\\\"10\\\",\\\"os\\\":\\\"windows-latest\\\",\\\"arch\\\":\\\"amd64\\\"},{\\\"version\\\":\\\"12\\\",\\\"os\\\":\\\"ubuntu-latest\\\",\\\"arch\\\":\\\"amd64\\\"},{\\\"version\\\":\\\"12\\\",\\\"os\\\":\\\"windows-latest\\\",\\\"arch\\\":\\\"amd64\\\"},{\\\"version\\\":\\\"14\\\",\\\"os\\\":\\\"ubuntu-latest\\\",\\\"arch\\\":\\\"amd64\\\"},{\\\"version\\\":\\\"14\\\",\\\"os\\\":\\\"windows-latest\\\",\\\"arch\\\":\\\"amd64\\\"}]}\"}]}"},{"name":"arm64","items":"{\"include\":[{\"name\":\"10-ubuntu-latest-arm64 - 14-windows-latest-arm64\",\"items\":\"{\\\"include\\\":[{\\\"version\\\":\\\"10\\\",\\\"os\\\":\\\"ubuntu-latest\\\",\\\"arch\\\":\\\"arm64\\\"},{\\\"version\\\":\\\"10\\\",\\\"os\\\":\\\"windows-latest\\\",\\\"arch\\\":\\\"arm64\\\"},{\\\"version\\\":\\\"12\\\",\\\"os\\\":\\\"ubuntu-latest\\\",\\\"arch\\\":\\\"arm64\\\"},{\\\"version\\\":\\\"12\\\",\\\"os\\\":\\\"windows-latest\\\",\\\"arch\\\":\\\"arm64\\\"},{\\\"version\\\":\\\"14\\\",\\\"os\\\":\\\"ubuntu-latest\\\",\\\"arch\\\":\\\"arm64\\\"},{\\\"version\\\":\\\"14\\\",\\\"os\\\":\\\"windows-latest\\\",\\\"arch\\\":\\\"arm64\\\"}]}\"}]}"}]}'


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

Supersedes #22
Supersedes #21

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
